### PR TITLE
Stop using reserved JavaScript keyword `package`

### DIFF
--- a/lib/package-foreman.js
+++ b/lib/package-foreman.js
@@ -27,27 +27,27 @@ export default {
     init();
   },
 
-  onPackageActivated(package) {
+  onPackageActivated(pack) {
     if (this.packagesLoaded) {
       readPackageManifest().then(manifest => {
-        const isInManifest = manifest.includes(package.name);
+        const isInManifest = manifest.includes(pack.name);
         if (!isInManifest) {
           atom.notifications.addInfo('Adding new package to manifest');
-          addPackageToManifest(package, manifest);
+          addPackageToManifest(pack, manifest);
         }
       });
     }
   },
 
-  onPackageDeactivated(package) {
+  onPackageDeactivated(pack) {
     if (this.packagesLoaded) {
-      const { name } = package;
+      const { name } = pack;
       isPackageInstalled(name).then(isInstalled => {
         if (isInstalled) {
           readPackageManifest().then(manifest => {
             const isInManifest = manifest.includes(name);
             if (isInManifest) {
-              removePackageFromManifest(package, manifest);
+              removePackageFromManifest(pack, manifest);
             }
           });
         }

--- a/lib/package.js
+++ b/lib/package.js
@@ -96,22 +96,22 @@ function installMissingPackages(manifest, installedPackages) {
   });
 }
 
-export function addPackageToManifest(package, manifest = undefined) {
+export function addPackageToManifest(pack, manifest = undefined) {
   if (manifest) {
-    writePackageManifest([...manifest, package.name]);
+    writePackageManifest([...manifest, pack.name]);
   } else {
     readPackageManifest().then(packageManifest => {
-      writePackageManifest([...packageManifest, package.name]);
+      writePackageManifest([...packageManifest, pack.name]);
     });
   }
 }
 
-export function removePackageFromManifest(package, manifest = undefined) {
+export function removePackageFromManifest(pack, manifest = undefined) {
   if (manifest) {
-    writePackageManifest(manifest.filter(p => p !== package.name));
+    writePackageManifest(manifest.filter(p => p !== pack.name));
   } else {
     readPackageManifest().then(packageManifest => {
-      writePackagedManifest(packageManifest.filter(p => p !== package.name));
+      writePackagedManifest(packageManifest.filter(p => p !== pack.name));
     });
   }
 }


### PR DESCRIPTION
In the process of upgrading babel in Atom core (https://github.com/atom/atom/pull/13823) we have noticed this package uses JavaScript features that are either deprecated or that are incompatible with the language specification.

This pull request changes the code to stop using such features so that the package keeps working when the babel upgrade will be merged and released.

I have enabled edits from maintainers, so feel free to make any changes to this branch! Also, please let me know if you have any questions or concerns and if I can help somehow. Thanks!